### PR TITLE
src/BuildingS2E.rst: Fix typo of mingw-64

### DIFF
--- a/src/BuildingS2E.rst
+++ b/src/BuildingS2E.rst
@@ -107,7 +107,7 @@ If you are going to be analyzing Windows binaries, you will also need to install
 
 .. code-block:: console
 
-    sudo apt-get install mingw-64
+    sudo apt-get install mingw-w64
 
 Checking out S2E
 ----------------


### PR DESCRIPTION
Fix `mingw-64` as `mingw-w64` when installing `mingw`