### PR TITLE
s2e-env: document S2E/KLEE args

### DIFF
--- a/src/s2e-env.rst
+++ b/src/s2e-env.rst
@@ -187,7 +187,9 @@ models.lua:
     For specifying `function models <Plugins/Linux/FunctionModels.rst>`_.
 
 s2e-config.lua
-   The main S2E configuration file. Analysis plugins are enabled and configured here.
+   The main S2E configuration file. Analysis plugins are enabled and configured here (in the ``pluginsConfig`` table).
+   S2E (and KLEE) arguments are also specified here (under ``kleeArgs`` in the ``s2e`` table). The available S2E
+   arguments are defined in `S2EExecutor.cpp <https://github.com/S2E/libs2ecore/blob/master/src/S2EExecutor.cpp>`_.
 
 Target program arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Sort of relates to https://github.com/S2E/libs2ecore/issues/8 (actually, not really). But in general, people don't seem to be aware that these different options exist (understandable). So I've just documented the fact that they exist.