### PR TITLE
Phased out Ubuntu 16 support

### DIFF
--- a/src/BuildingS2E.rst
+++ b/src/BuildingS2E.rst
@@ -8,8 +8,8 @@ to run them manually.
 
 .. note::
 
-    S2E builds and runs on Ubuntu 16.04 LTS and 18.04 LTS (64-bit).
-    Ubuntu 14.04 LTS may still work, but we do not support it anymore.
+    S2E builds and runs on Ubuntu 18.04 LTS (64-bit).
+    Earlier versions may still work, but we do not support them anymore.
 
 
 Building using Docker
@@ -54,9 +54,6 @@ Building S2E manually
 =====================
 
 In addition to using the ``s2e-env`` tool, you can also build S2E manually.
-
-**NOTE**: If you are using Ubuntu 14.04 you must install CMake manually - S2E requires version 3.4.3 or newer, which is
-not available in the Ubuntu 14.04 repositories.
 
 Required packages
 -----------------

--- a/src/s2e-env.rst
+++ b/src/s2e-env.rst
@@ -11,8 +11,8 @@ with S2E. It entirely automates the complex tasks of building guest VM images re
 generating configuration files to run various types of binaries. The following steps describe how to use ``s2e-env``.
 You will find in the documentation various tutorials that go deeper into various topics.
 
-Before you start, make sure you have a working 64-bit Ubuntu 16.04 LTS or 18.04 LTS installation. Ubuntu 14.04 LTS may
-still work, but we do not actively support it anymore.
+Before you start, make sure you have a working 64-bit Ubuntu 18.04 LTS installation. Earlier versions may
+still work, but we do not actively support them anymore.
 
 .. contents::
 


### PR DESCRIPTION
It has problems with glib, 32 and 64-bit dev packages can't be installed together

Signed-off-by: Vitaly Chipounov <vitaly@cyberhaven.io>